### PR TITLE
Flag to refresh after configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ Parameter | Data type | Description | Default
 `service_ensure`   | Stdlib::Ensure::Service | Whether proxysql should be running.                  | 'running'
 `service_enable`   | Boolean                 | Whether proxysql should be enabled to start at boot. | true
 `configs`          | Hash                    | The Configuration hashes for proxysql.cnf            | See [data/common.yaml](./data/common.yaml)
+`refresh_from_config` | Boolean              | Whether proxysql should be restarted after updating configuration. | false
 
 #### Private Classes
 

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -43,3 +43,4 @@ proxysql::configs:
   mysql_query_rules: {}
   scheduler: {}
   mysql_replication_hostgroups: {}
+proxysql::refresh_from_config: false

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -83,6 +83,7 @@ class proxysql (
   Stdlib::Ensure::Service $service_ensure,
   Boolean                 $service_enable,
   Hash                    $configs,
+  Boolean                 $refresh_from_config,
 ) {
 
   include proxysql::repo
@@ -93,6 +94,11 @@ class proxysql (
   Class['::proxysql::repo']
   -> Class['::proxysql::install']
   -> Class['::proxysql::config']
-  ~> Class['::proxysql::service']
+
+  if $refresh_from_config {
+    Class['::proxysql::config'] ~> Class['::proxysql::service']
+  } else {
+    Class['::proxysql::config'] -> Class['::proxysql::service']
+  }
 
 }

--- a/spec/classes/proxysql_spec.rb
+++ b/spec/classes/proxysql_spec.rb
@@ -11,7 +11,7 @@ describe 'proxysql' do
       it { is_expected.to contain_class('proxysql::repo') }
       it { is_expected.to contain_class('proxysql::install').that_requires('Class[proxysql::repo]') }
       it { is_expected.to contain_class('proxysql::config').that_requires('Class[proxysql::install]') }
-      it { is_expected.to contain_class('proxysql::service').that_requires_to('Class[proxysql::config]') }
+      it { is_expected.to contain_class('proxysql::service').that_requires('Class[proxysql::config]') }
 
       if os_facts[:operatingsystem] =~ %r{Debian|Ubuntu}
         it { is_expected.to contain_package('lsb-release') }

--- a/spec/classes/proxysql_spec.rb
+++ b/spec/classes/proxysql_spec.rb
@@ -11,7 +11,7 @@ describe 'proxysql' do
       it { is_expected.to contain_class('proxysql::repo') }
       it { is_expected.to contain_class('proxysql::install').that_requires('Class[proxysql::repo]') }
       it { is_expected.to contain_class('proxysql::config').that_requires('Class[proxysql::install]') }
-      it { is_expected.to contain_class('proxysql::service').that_subscribes_to('Class[proxysql::config]') }
+      it { is_expected.to contain_class('proxysql::service').that_requires_to('Class[proxysql::config]') }
 
       if os_facts[:operatingsystem] =~ %r{Debian|Ubuntu}
         it { is_expected.to contain_package('lsb-release') }


### PR DESCRIPTION
ProxySQL can reload from the configuration file at runtime without restarting process.