### PR TITLE
Set show_diff of proxysql.cnf to false by default.

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ Parameter | Data type | Description | Default
 `logdir_mode`      | Stdlib::Filemode        | The permissions for the log directory.               | '0700'
 `configfile`       | Stdlib::Absolutepath    | Path to configuration file.                          | '/etc/proxysql.cnf'
 `configfile_mode`  | Stdlib::Filemode        | The permissions for the config file.                 | '0600'
+`configfile_show_diff` | Boolean             | Whether to display differences when the file changes | false
 `service_ensure`   | Stdlib::Ensure::Service | Whether proxysql should be running.                  | 'running'
 `service_enable`   | Boolean                 | Whether proxysql should be enabled to start at boot. | true
 `configs`          | Hash                    | The Configuration hashes for proxysql.cnf            | See [data/common.yaml](./data/common.yaml)

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -8,6 +8,7 @@ proxysql::logdir: '/var/log/proxysql'
 proxysql::logdir_mode: '0700'
 proxysql::configfile: '/etc/proxysql.cnf'
 proxysql::configfile_mode: '0600'
+proxysql::configfile_show_diff: false
 proxysql::service_ensure: 'running'
 proxysql::service_enable: true
 proxysql::configs:
@@ -44,4 +45,3 @@ proxysql::configs:
   scheduler: {}
   mysql_replication_hostgroups: {}
 proxysql::refresh_from_config: false
-proxysql::configfile_show_diff: false

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -44,3 +44,4 @@ proxysql::configs:
   scheduler: {}
   mysql_replication_hostgroups: {}
 proxysql::refresh_from_config: false
+proxysql::configfile_show_diff: false

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -4,11 +4,12 @@
 class proxysql::config {
 
   file { $proxysql::configfile:
-    ensure  => file,
-    owner   => $proxysql::owner,
-    group   => $proxysql::group,
-    mode    => $proxysql::configfile_mode,
-    content => epp('proxysql/proxysql.cnf.epp'),
+    ensure    => file,
+    owner     => $proxysql::owner,
+    group     => $proxysql::group,
+    mode      => $proxysql::configfile_mode,
+    content   => epp('proxysql/proxysql.cnf.epp'),
+    show_diff => $proxysql::configfile_show_diff,
   }
 
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -80,6 +80,7 @@ class proxysql (
   Stdlib::Filemode        $logdir_mode,
   Stdlib::Absolutepath    $configfile,
   Stdlib::Filemode        $configfile_mode,
+  Boolean                 $configfile_show_diff,
   Stdlib::Ensure::Service $service_ensure,
   Boolean                 $service_enable,
   Hash                    $configs,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -63,6 +63,8 @@
 #   The path to the default configuration.
 # @param configfile_mode
 #   The desired permissions mode for the file, in symbolic or numeric notation.
+# @param configfile_show_diff
+#   Whether to display differences when the file changes, defaulting to false.
 # @param service_ensure
 #   Whether a service should be running.
 # @param service_enable


### PR DESCRIPTION
proxysql.cnf includes secret such as admin credentials, monitoring user, mysql users, and so on.